### PR TITLE
Apply null-safety and Dart 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,7 @@
 
 * Generate 8 bit audio
 * Sin / Square / Triangle waves
+
+## [0.1.1] - Null-safety
+
+* Migrated to null-safety standards

--- a/README.md
+++ b/README.md
@@ -48,3 +48,4 @@ Or string together a sequence of Notes
 
 * Sin, Square, Triangle waves
 * 8 Bit depth
+* Null-safety

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: wave_generator
 description: A dart package to generate audio wave data on the fly
-version: 0.1.0
+version: 0.1.1
 homepage: https://github.com/patchandthat/wave-generator
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '^3.0.6'
 
 dev_dependencies:
-  lints: ^1.0.1
+  lints: ^2.1.1
   test: ^1.20.2


### PR DESCRIPTION
dart pub outdated
![image](https://github.com/patchandthat/wave-generator/assets/40308971/f1e671ef-fcb3-42a0-a996-e4baaa2e33e6)

dart test
![image](https://github.com/patchandthat/wave-generator/assets/40308971/f913ff69-b0b4-4e20-9a58-c1194df704de)

dart pub get
![image](https://github.com/patchandthat/wave-generator/assets/40308971/1817bed3-d1e5-4011-bd9a-bec472667fcb)


This package is too valuable to be deprecated. Please this PR is for this project to be used by others who need it. Thank you for the package, very grateful!